### PR TITLE
Fix up Pip dependencies to allow scripts to be installed standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # py-mapzen-whosonfirst-hierarchy
 
-Simple Python wrapper for Who's On First hierarchies. 
+Simple Python wrapper for Who's On First hierarchies.
+
+## Installation
+
+```
+sudo pip install -r requirements.txt .
+```
 
 ## Usage
 
@@ -84,7 +90,7 @@ ancs = mapzen.whosonfirst.hierarchy.ancestors(spatial_client=pg_client)
 updated_repos = ancs.rebuild_and_export_feature(feature, data_root=data_root)
 ```
 
-The `rebuild_descendants_and_export_feature` method will return a list of all the unique WOF repos which have records that have been changed. 
+The `rebuild_descendants_and_export_feature` method will return a list of all the unique WOF repos which have records that have been changed.
 
 It seems like it would be nice to be able to define your own callback, but today you can not.
 
@@ -101,7 +107,20 @@ Usage: wof-hierarchy-rebuild [options] /path/to/wof/record.geojson
 Options:
   -h, --help            show this help message and exit
   -C CLIENT, --client=CLIENT
-                        A valid mapzen.whosonfirst.spatial spatial client. Default is 'postgis'
+                        A valid mapzen.whosonfirst.spatial spatial client.
+                        (default is 'postgis')
+  -U, --update          ... (default is False)
+  -D DATA_ROOT, --data_root=DATA_ROOT
+                        ... (default is '/usr/local/data')
+  --pgis-host=PGIS_HOST
+                        ...(default is 'localhost')
+  --pgis-username=PGIS_USERNAME
+                        ... (default is 'whosonfirst')
+  --pgis-password=PGIS_PASSWORD
+                        ... (default is None)
+  --pgis-database=PGIS_DATABASE
+                        ... (default is 'whosonfirst')
+  -H, --show-hierarchy  ... (default is False)
   -v, --verbose         Be chatty (default is false)
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,12 @@
 git+https://github.com/whosonfirst/py-mapzen-whosonfirst-placetypes
 git+https://github.com/whosonfirst/py-mapzen-whosonfirst-export
 git+https://github.com/whosonfirst/py-mapzen-whosonfirst-utils
+git+https://github.com/whosonfirst/py-mapzen-whosonfirst-meta
+git+https://github.com/whosonfirst/py-mapzen-whosonfirst-sources
+git+https://github.com/whosonfirst/python-edtf
+git+https://github.com/whosonfirst/py-mapzen-whosonfirst-geojson
+arrow
+atomicwrites
 deepdiff
+gdal==2.4.4
+geojson


### PR DESCRIPTION
Fixed up unresolved dependencies to allow a clone of this repo, followed by a `pip install`, to install cleanly and so to be able to, err, run the scripts

Also added a small update to the README on installation, plus updating the help text from `wof-rebuild-hierarchy` to reflect the current state of the script.

The only thing I'm unhappy about in this PR is having to lock GDAL to a specific version. Adding `gdal` to `requirements.txt` causes the build to barf horribly, but explicitly stating the version number to align with the current, latest version of GDAL (installed via Homebrew) seems to do the trick. Whether this trick is acceptable or not is a matter for discussion though.